### PR TITLE
Fix title on arrow for moving column right

### DIFF
--- a/src/components/column.tsx
+++ b/src/components/column.tsx
@@ -197,7 +197,7 @@ function Column({
                 </a>
                 <a
                     className="column-right"
-                    title="Move Column Left"
+                    title="Move Column Right"
                     {...anchorProps}
                     style={{
                         display: index < numCols - 1 ? 'block' : 'none',


### PR DESCRIPTION
Title on arrow for moving column right incorrectly says "Move Column Left".
This fix changes text to "Move Column Right".