### PR TITLE
1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 1.7.1
+
+-   Removed small gaps between history elements
+-   "Hide Settings" button has correct tooltip
+-   Task colors are brighter for light themes
+-   Can create multiple line breaks in a task with "\\"
+
 ## 1.7.0
 
 -   Revision History shows current board state

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "react-hot-toast": "^2.1.0",
     "react-markdown": "^8.0.3",
     "react-textarea-autosize": "^8.3.3",
+    "remark-breaks": "^3.0.2",
     "remark-gfm": "^3.0.1"
   },
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Kanban",
   "description": "Simple kanban board for VS Code. Visually organize your ideas!",
   "icon": "images/icon.png",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "engines": {
     "vscode": "^1.53.2"
   },

--- a/src/components/board.css
+++ b/src/components/board.css
@@ -1,5 +1,10 @@
 /* Imported by index.css, do NOT import manually */
 
+:root {
+    --board-background: var(--vscode-editor-background);
+    --board-foreground: var(--vscode-editor-foreground);
+}
+
 .board {
     width: 95%;
     height: 95%;
@@ -19,8 +24,8 @@
 }
 
 .board-title {
-    background-color: var(--vscode-editor-background);
-    color: var(--vscode-editor-foreground);
+    background-color: var(--board-background);
+    color: var(--board-foreground);
     font-size: 2rem;
     margin: 0;
     font-weight: bold;
@@ -28,11 +33,11 @@
 }
 
 .board-title:focus {
-    outline-color: var(--vscode-editor-foreground);
+    outline-color: var(--board-foreground);
 }
 
 .board-titlebar a {
-    color: var(--vscode-editor-foreground);
+    color: var(--board-foreground);
 }
 
 .board-titlebar .codicon {
@@ -50,8 +55,8 @@
 .board-titlebar .codicon:hover,
 .board-titlebar .codicon:focus,
 .board-titlebar .codicon:active {
-    color: var(--vscode-editor-background);
-    background-color: var(--vscode-editor-foreground);
+    color: var(--board-background);
+    background-color: var(--board-foreground);
 }
 
 .board-save .codicon.codicon-pass-filled {
@@ -59,7 +64,7 @@
     top: 0.7rem;
     right: -0.3rem;
     font-size: 1rem !important;
-    background: radial-gradient(var(--vscode-editor-background) 28%, transparent 28%)
+    background: radial-gradient(var(--board-background) 28%, transparent 28%)
 }
 
 .board-content {
@@ -77,7 +82,7 @@
     height: 100%;
     opacity: 0.3;
     cursor: pointer;
-    color: var(--vscode-editor-foreground) !important;
+    color: var(--board-foreground) !important;
     transition: opacity 0.2s;
     text-align: center;
 }
@@ -99,7 +104,7 @@
     content: '';
     display: block;
     background: none;
-    border-right: 0.08rem solid var(--vscode-editor-foreground);
+    border-right: 0.08rem solid var(--board-foreground);
     width: 50%;
 }
 
@@ -107,7 +112,7 @@
     content: '';
     display: block;
     background: none;
-    border-left: 0.08rem solid var(--vscode-editor-foreground);
+    border-left: 0.08rem solid var(--board-foreground);
     width: 50%;
 }
 

--- a/src/components/board.test.tsx
+++ b/src/components/board.test.tsx
@@ -10,6 +10,7 @@ jest.mock('react-markdown', () => (props: any) => {
 });
 
 jest.mock('remark-gfm', () => () => {});
+jest.mock('remark-breaks', () => () => {});
 
 function* boardSetup() {
     const defaultKanban = createKanbanJson();

--- a/src/components/column.css
+++ b/src/components/column.css
@@ -1,11 +1,16 @@
 /* Imported by index.css, do NOT import manually */
 
+:root {
+    --column-background: var(--vscode-editor-background);
+    --column-foreground: var(--vscode-editor-foreground);
+}
+
 .column {
     flex-basis: 0;
     flex-grow: 1;
     flex-direction: column;
     display: flex;
-    border-left: 0.2rem solid var(--vscode-editor-foreground);
+    border-left: 0.2rem solid var(--column-foreground);
     padding-left: 0.3rem;
     transition: border-color 0.3s;
     min-width: 10.5rem;
@@ -20,8 +25,7 @@
 }
 
 .column-title {
-    background-color: var(--vscode-editor-background);
-    color: var(--vscode-editor-foreground);
+    background-color: var(--column-background);
     font-size: 1.25rem;
     margin: 0;
     font-weight: bold;
@@ -32,7 +36,6 @@
 
 .column-titlebar a,
 .column-settings a {
-    color: var(--vscode-editor-foreground);
     padding-left: 0.2rem;
     padding-right: 0.2rem;
     transition: background-color 0.3s, color 0.3s;
@@ -45,7 +48,7 @@
 .column-settings a:hover,
 .column-settings a:focus,
 .column-settings a:active {
-    color: var(--vscode-editor-background) !important;
+    color: var(--column-background) !important;
 }
 
 .column-titlebar .codicon[class*='codicon-'],
@@ -86,7 +89,7 @@
 
 .column-color-picker__swatch:focus {
     outline: none;
-    border: 0.1rem solid var(--vscode-editor-foreground);
+    border: 0.1rem solid var(--column-foreground);
 }
 
 .column-color-picker .text-picker {
@@ -104,8 +107,8 @@
     height: 100%;
     width: 100%;
     border: none;
-    background-color: var(--vscode-editor-background);
-    color: var(--vscode-editor-foreground);
+    background-color: var(--column-background);
+    color: var(--column-foreground);
     border: 1px solid var(--vscode-activityBar-background);
     box-sizing: border-box;
 }

--- a/src/components/column.test.tsx
+++ b/src/components/column.test.tsx
@@ -29,6 +29,7 @@ jest.mock('react-markdown', () => (props: any) => {
 });
 
 jest.mock('remark-gfm', () => () => {});
+jest.mock('remark-breaks', () => () => {});
 
 const defaultKanban = createKanbanJson('', [createColumnJson()]);
 const defaultColumn = defaultKanban.cols[0];

--- a/src/components/column.tsx
+++ b/src/components/column.tsx
@@ -98,8 +98,6 @@ function Column({ data, numCols, index }: { data: ColumnJson; numCols: number; i
             (event.currentTarget.style.backgroundColor = 'inherit'),
     } as const;
 
-    const colorFilter = data.color + '40';
-
     return (
         <div
             className="column"
@@ -261,7 +259,7 @@ function Column({ data, numCols, index }: { data: ColumnJson; numCols: number; i
                                 columnId={data.id}
                                 columnIndex={index}
                                 defaultToEdit={IdOfTaskJustAdded === task.id}
-                                colorFilter={colorFilter}
+                                columnColor={data.color}
                             />
                         ))}
                         {provided.placeholder}

--- a/src/components/revision-history.css
+++ b/src/components/revision-history.css
@@ -1,8 +1,14 @@
 /* Imported by index.css, do NOT import manually */
 
+:root {
+    --history-background: var(--vscode-editor-background);
+    --history-foreground: var(--vscode-editor-foreground);
+    --history-link: var(--vscode-editor-selectionBackground);
+}
+
 .history {
-    background-color: var(--vscode-editor-background);
-    color: var(--vscode-editor-foreground);
+    background-color: var(--history-background);
+    color: var(--history-foreground);
     height: 100%;
     flex-direction: column;
     align-items: center;
@@ -21,7 +27,7 @@
 
 .history-titlebar a {
     cursor: pointer;
-    color: var(--vscode-editor-foreground) !important;
+    color: var(--history-foreground) !important;
     font-size: 2.5rem !important;
     margin-left: -0.5rem;
     margin-right: 0.5rem;
@@ -37,7 +43,7 @@
 .history-titlebar a:hover .codicon,
 .history-titlebar a:focus .codicon,
 .history-titlebar a:active .codicon {
-    color: var(--vscode-editor-selectionBackground) !important;
+    color: var(--history-link) !important;
 }
 
 .history-scroller {
@@ -53,9 +59,9 @@
 }
 
 .history-item {
-    background-color: var(--vscode-editor-background);
-    color: var(--vscode-editor-foreground);
-    border-left: 0.2rem solid var(--vscode-editor-foreground);
+    background-color: var(--history-background);
+    color: var(--history-foreground);
+    border-left: 0.2rem solid var(--history-foreground);
     width: 90%;
     margin-top: 0.5rem;
     padding-left: 0.5rem;
@@ -66,6 +72,6 @@
 .history-item:hover,
 .history-item:focus,
 .history-item:active {
-    color: var(--vscode-editor-selectionBackground);
-    border-color: var(--vscode-editor-selectionBackground);
+    color: var(--history-link);
+    border-color: var(--history-link);
 }

--- a/src/components/revision-history.css
+++ b/src/components/revision-history.css
@@ -61,12 +61,16 @@
 .history-item {
     background-color: var(--history-background);
     color: var(--history-foreground);
-    border-left: 0.2rem solid var(--history-foreground);
     width: 90%;
-    margin-top: 0.5rem;
-    padding-left: 0.5rem;
     cursor: pointer;
     transition: 0.2s;
+}
+
+.history-item-inside {
+    margin-top: 0.5rem;
+    border-left: 0.2rem solid var(--history-foreground);
+    padding-left: 0.5rem;
+    display: inline-block;
 }
 
 .history-item:hover,

--- a/src/components/revision-history.tsx
+++ b/src/components/revision-history.tsx
@@ -56,8 +56,10 @@ class RevisionHistory extends React.Component<{}, { history: HistoryObject[]; op
                                 onMouseEnter={() => boardState.displayKanban(histObj.data)}
                                 onMouseLeave={() => boardState.refreshKanban()}
                             >
-                                <h3>{`${index + 1}. ${this.stateChangeName(prevChange)}`}</h3>
-                                <p> {prevDetail} </p>
+                                <div className="history-item-inside">
+                                    <h3>{`${index + 1}. ${this.stateChangeName(prevChange)}`}</h3>
+                                    <p> {prevDetail} </p>{' '}
+                                </div>
                             </a>
                         );
                     })}
@@ -78,8 +80,12 @@ class RevisionHistory extends React.Component<{}, { history: HistoryObject[]; op
                                 onMouseEnter={() => boardState.refreshKanban()}
                                 onMouseLeave={() => boardState.refreshKanban()}
                             >
-                                <h3> {`${this.state.history.length + 1}. ${mostRecentChange}`}</h3>
-                                <p> {mostRecentDetail} </p>
+                                <div className="history-item-inside">
+                                    <h3>
+                                        {`${this.state.history.length + 1}. ${mostRecentChange}`}
+                                    </h3>
+                                    <p> {mostRecentDetail} </p>
+                                </div>
                             </a>
                         );
                     })()}

--- a/src/components/settings.css
+++ b/src/components/settings.css
@@ -1,8 +1,14 @@
 /* Imported by index.css, do NOT import manually */
 
+:root {
+    --settings-background: var(--vscode-editor-background);
+    --settings-foreground: var(--vscode-editor-foreground);
+    --settings-link: var(--vscode-editor-selectionBackground);
+}
+
 .settings {
-    background-color: var(--vscode-editor-background);
-    color: var(--vscode-editor-foreground);
+    background-color: var(--settings-background);
+    color: var(--settings-foreground);
     height: 100%;
     flex-direction: column;
     align-items: center;
@@ -36,7 +42,7 @@
 
 .settings-titlebar a {
     cursor: pointer;
-    color: var(--vscode-editor-foreground) !important;
+    color: var(--settings-foreground) !important;
     font-size: 2.5rem !important;
     margin-left: 0.5rem;
 }
@@ -51,14 +57,14 @@
 .settings-titlebar a:hover .codicon,
 .settings-titlebar a:focus .codicon,
 .settings-titlebar a:active .codicon {
-    color: var(--vscode-editor-selectionBackground) !important;
+    color: var(--settings-link) !important;
 }
 
 
 a.settings-link {
     cursor: pointer;
-    color: var(--vscode-editor-foreground) !important;
-    /* border-bottom: 1px var(--vscode-editor-foreground) solid; */
+    color: var(--settings-foreground) !important;
+    /* border-bottom: 1px var(--settings-foreground) solid; */
     padding: 3px;
     padding-right: 5px;
     transition: 0.2s;
@@ -74,8 +80,8 @@ a.settings-link .codicon {
 a.settings-link:hover,
 a.settings-link:focus,
 a.settings-link:active {
-    color: var(--vscode-editor-selectionBackground) !important;
-    /* border-color: var(--vscode-editor-selectionBackground); */
+    color: var(--settings-link) !important;
+    /* border-color: var(--settings-link); */
 }
 
 
@@ -113,7 +119,7 @@ a.settings-link:active {
     height: 1.8rem;
     border-radius: 1.6rem;
     transition: 0.2s;
-    background-color: var(--vscode-editor-foreground);
+    background-color: var(--settings-foreground);
     box-shadow: 0 0 2px 0 rgba(10, 10, 10, 0.29);
     text-align: center;
 }
@@ -125,7 +131,7 @@ a.settings-link:active {
 
 .toggle-switch-button .codicon {
     font-size: 1.5rem !important;
-    color: var(--vscode-editor-background);
+    color: var(--settings-background);
     margin-top: 0.15rem;
     margin-left: 0.05rem;
     transition: color 0.3s;

--- a/src/components/settings.css
+++ b/src/components/settings.css
@@ -81,7 +81,6 @@ a.settings-link:hover,
 a.settings-link:focus,
 a.settings-link:active {
     color: var(--settings-link) !important;
-    /* border-color: var(--settings-link); */
 }
 
 

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -42,7 +42,7 @@ class SettingsPanel extends React.Component<
         return (
             <div className="settings" style={style}>
                 <div className="settings-titlebar">
-                    <a onClick={() => this.setState({ open: false })} title="Hide Revision History">
+                    <a onClick={() => this.setState({ open: false })} title="Hide Settings">
                         <span className="codicon codicon-chevron-left" />
                     </a>
                     <h1> Settings </h1>

--- a/src/components/task.css
+++ b/src/components/task.css
@@ -8,7 +8,7 @@
 
 .task {
     margin-top: 0.5rem;
-    background-color: var(--task-background);
+    background-color: #3e3e3e;
 }
 
 .task-handle {

--- a/src/components/task.css
+++ b/src/components/task.css
@@ -9,7 +9,6 @@
 .task {
     margin-top: 0.5rem;
     background-color: var(--task-background);
-    /* color: var(--task-foreground); */
 }
 
 .task-handle {
@@ -94,4 +93,8 @@
     overflow: hidden;
     animation-direction: reverse;
     pointer-events: none;
+}
+
+.half-opacity {
+    opacity: 0.5;
 }

--- a/src/components/task.css
+++ b/src/components/task.css
@@ -1,9 +1,15 @@
 /* Imported by index.css, do NOT import manually */
 
+:root {
+    --task-background: var(--vscode-activityBar-background);
+    --task-foreground: var(--vscode-chart);
+    --task-icon: var(--vscode-activityBar-foreground);
+}
+
 .task {
     margin-top: 0.5rem;
-    background-color: var(--vscode-activityBar-background);
-    color: var(--vscode-chart);
+    background-color: var(--task-background);
+    /* color: var(--task-foreground); */
 }
 
 .task-handle {
@@ -21,21 +27,21 @@
 }
 
 .task-handle .codicon-gripper {
-    color: var(--vscode-activityBar-foreground);
+    color: var(--task-icon);
     opacity: 0.25;
 }
 
 .task-delete {
     transition: background-color 0.3s, color 0.3s;
-    color: var(--vscode-activityBar-foreground);
+    color: var(--task-icon);
     cursor: pointer;
 }
 
 .task-delete:hover,
 .task-delete:focus,
 .task-delete:active {
-    color: var(--vscode-activityBar-background);
-    background-color: var(--vscode-activityBar-foreground);
+    color: var(--task-background);
+    background-color: var(--task-icon);
 }
 
 .task-section {
@@ -44,7 +50,7 @@
     color: var(--vscode-editor-foreground);
     margin: 0 !important;
     width: 100% !important;
-    border: 1px solid var(--vscode-activityBar-background);
+    border: 1px solid var(--task-background);
     box-sizing: border-box !important;
     cursor: text;
     transition: border-color 0.2s;

--- a/src/components/task.test.tsx
+++ b/src/components/task.test.tsx
@@ -17,7 +17,7 @@ function* taskSetup() {
             columnId={defaultColumn.id}
             columnIndex={0}
             defaultToEdit={false}
-            colorFilter={'#ffffff40'}
+            columnColor={'#ffffff'}
         />
     );
     const task = wrapper.container.firstElementChild as HTMLDivElement;
@@ -62,7 +62,7 @@ describe('<Task>', () => {
                 columnId={''}
                 columnIndex={0}
                 defaultToEdit={false}
-                colorFilter={'#ffffff40'}
+                columnColor={'#ffffff'}
             />
         );
         const task = wrapper.container.firstElementChild as HTMLDivElement;
@@ -85,7 +85,7 @@ describe('<Task>', () => {
                 columnId={''}
                 columnIndex={0}
                 defaultToEdit={true}
-                colorFilter={'#ffffff40'}
+                columnColor={'#ffffff'}
             />
         );
 

--- a/src/components/task.test.tsx
+++ b/src/components/task.test.tsx
@@ -50,6 +50,7 @@ jest.mock('react-markdown', () => (props: any) => {
 });
 
 jest.mock('remark-gfm', () => () => {});
+jest.mock('remark-breaks', () => () => {});
 
 describe('<Task>', () => {
     it('Renders a task', () => {

--- a/src/components/task.tsx
+++ b/src/components/task.tsx
@@ -29,7 +29,7 @@ function colorToFilter(color: string, filterStrengh: number) {
     if (color[0] === '#') {
         return color + (filterStrengh * 256).toString(16).padStart(2, '0');
     } else {
-        return `rgba${color.slice(3, -1)}, 0.25)`;
+        return `rgba${color.slice(3, -1)}, ${filterStrengh})`;
     }
 }
 

--- a/src/components/task.tsx
+++ b/src/components/task.tsx
@@ -6,6 +6,7 @@ import boardState from '../util/board-state';
 import { TaskJson } from '../util/kanban-types';
 import remarkGfm from 'remark-gfm';
 import vscodeHandler, { ColorTheme } from '../util/vscode-handler';
+import remarkBreaks from 'remark-breaks';
 
 let previousFocusedTaskId = '';
 let anyTaskIsFocused = false;
@@ -176,7 +177,7 @@ function Task({
                             id={`${data.id}-display`}
                         >
                             <ReactMarkdown
-                                remarkPlugins={[remarkGfm]}
+                                remarkPlugins={[remarkGfm, remarkBreaks]}
                                 className={data.text ? '' : 'half-opacity'}
                             >
                                 {data.text || '_enter text or markdown here_'}

--- a/src/components/task.tsx
+++ b/src/components/task.tsx
@@ -150,7 +150,10 @@ function Task({
                             }}
                             id={`${data.id}-display`}
                         >
-                            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                            <ReactMarkdown
+                                remarkPlugins={[remarkGfm]}
+                                className={data.text ? '' : 'half-opacity'}
+                            >
                                 {data.text || '_enter text or markdown here_'}
                             </ReactMarkdown>
                         </div>

--- a/src/components/task.tsx
+++ b/src/components/task.tsx
@@ -5,9 +5,32 @@ import { Draggable } from 'react-beautiful-dnd';
 import boardState from '../util/board-state';
 import { TaskJson } from '../util/kanban-types';
 import remarkGfm from 'remark-gfm';
+import vscodeHandler, { ColorTheme } from '../util/vscode-handler';
 
 let previousFocusedTaskId = '';
 let anyTaskIsFocused = false;
+let isLightMode = document.querySelector('body')!.classList.contains('vscode-light');
+
+const lightModeListener = (theme: ColorTheme) => {
+    isLightMode = theme === ColorTheme.THEME_LIGHT || theme === ColorTheme.THEME_LIGHT_HIGHCONTRAST;
+    boardState.refreshKanban();
+};
+vscodeHandler.addThemeChangeListener(lightModeListener);
+
+/**
+ * Converts css color to one with reduced opacity. Does no input checking.
+ *
+ * @param color string with 2 forms: "#RRGGBB" or "rgb(R, G, B)".
+ * @param filterStrengh number betwen 0 and 1 (inclusive)
+ * @returns color with reduced opacity
+ */
+function colorToFilter(color: string, filterStrengh: number) {
+    if (color[0] === '#') {
+        return color + (filterStrengh * 256).toString(16).padStart(2, '0');
+    } else {
+        return `rgba${color.slice(3, -1)}, 0.25)`;
+    }
+}
 
 /**
  * Listens for the keyboard shortcut 'Ctrl + Enter'. If a task is currently being edited,
@@ -40,37 +63,39 @@ function Task({
     columnId,
     defaultToEdit, // aka Task just added
     columnIndex,
-    colorFilter,
+    columnColor,
 }: {
     data: TaskJson;
     index: number;
     columnId: string;
     defaultToEdit: boolean;
     columnIndex: number;
-    colorFilter: string; //#RRGGBB40
+    columnColor: string; //#RRGGBB40
 }): JSX.Element {
     const [editing, setEditing] = React.useState(defaultToEdit);
     const [text, setText] = React.useState(data.text);
     const [beingDeleted, setBeingDeleted] = React.useState(false);
+
+    const filterStrengh = isLightMode ? 0.75 : 0.25;
 
     return (
         <Draggable key={data.id} draggableId={data.id} index={index}>
             {(provided, snapshot) => {
                 const beingDragged = snapshot.isDragging && !snapshot.isDropAnimating;
 
+                columnColor = colorToFilter(columnColor, filterStrengh);
                 if (snapshot.isDropAnimating) {
                     // transition to target column's color instead of home column's
                     const targetColumn = document.getElementById(snapshot.draggingOver ?? '');
                     if (targetColumn) {
-                        const targetColor = targetColumn.style.color; // rgb(r, g, b)
-                        colorFilter = `rgba${targetColor.slice(3, -1)}, 0.25)`; // 0x40 / 0xFF ~= 0.25
+                        columnColor = colorToFilter(targetColumn.style.color, filterStrengh); // rgb -> rgba
                     }
                 }
 
-                let bgColor = beingDragged ? 'rgba(0,0,0,0)' : colorFilter;
+                let bgColor = beingDragged ? 'rgba(0,0,0,0)' : columnColor;
                 let borderColor = beingDragged
                     ? 'var(--vscode-activityBar-background)'
-                    : colorFilter;
+                    : columnColor;
 
                 //draggable container for the task (see react-beautiful-dnd)
                 return (

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 
 const path = require('path');
 const miniCss = require('mini-css-extract-plugin');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4581,6 +4581,15 @@ regexpp@^3.1.0:
   resolved "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
+remark-breaks@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/remark-breaks/-/remark-breaks-3.0.2.tgz#f466b9d3474d7323146c0149fc1496dabadd908e"
+  integrity sha512-x96YDJ9X+Ry0/JNZFKfr1hpcAKvGYWfUTszxY9RbxKEqq6uzPPoLCuHdZsLPZZUdAv3nCROyc7FPrQLWr2rxyw==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    unified "^10.0.0"
+    unist-util-visit "^4.0.0"
+
 remark-gfm@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-3.0.1.tgz#0b180f095e3036545e9dddac0e8df3fa5cfee54f"


### PR DESCRIPTION
## Changelog

### 1.7.1

-   Removed small gaps between history elements
-   "Hide Settings" button has correct tooltip
-   Task colors are brighter for light themes
-   Can create multiple line breaks in a task with "\\"

## Internal Changes
- Added a listener for color theme change so board will update automatically on theme change
- added dependency for `remark-breaks` to implement multiple newlines
- Made new CSS vars for Kanban rather than just using the "vscode-*" ones