### PR TITLE
1.7.3 (reduced filesize)

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,7 @@
+.github/
 .vscode/
+coverage/
+docs/
 
 images/
 !images/icon.png
@@ -8,17 +11,22 @@ node_modules/
 !node_modules/@vscode/codicons/dist/codicon.ttf
 !node_modules/@szhsin/react-menu/dist/index.css
 
-public/
 src/
-coverage/
 
 .eslintrc.json
 .gitignore
+.prettierrc.yaml
+
 .yarnrc
+
 jest.config.js
+jsdoc.conf.js
+*.vsix
+
 tsconfig.extension.json
 tsconfig.json
+
+webpack-extension.config.js
+webpack.config.js
 yarn-error.log
 yarn.lock
-*.vsix
-webpack.config.js

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Kanban",
   "description": "Simple kanban board for VS Code. Visually organize your ideas!",
   "icon": "images/icon.png",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "engines": {
     "vscode": "^1.53.2"
   },


### PR DESCRIPTION
Added files and directories to `.vscodeignore` that should have been there all along. Namely the `docs` folder. This reduced package size back to a reasonable 200 KB instead of 700 (yikes!).