### PR TITLE
only validate color text on blur so that text box is editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.8.1
+
+-   Fixed column color picker not responding to text edits
+
 ## 1.8.0
 
 -   Bugfixes:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Kanban",
   "description": "Simple kanban board for VS Code. Visually organize your ideas!",
   "icon": "images/icon.png",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "engines": {
     "vscode": "^1.53.2"
   },

--- a/src/components/column/color-picker.tsx
+++ b/src/components/column/color-picker.tsx
@@ -67,12 +67,7 @@ export default function ColorPicker({
     const swatches = boardState.isLightMode ? lightSwatches : darkSwatches;
 
     const onInputChange = React.useCallback(
-        (event: React.ChangeEvent<HTMLInputElement>) => {
-            const newColor = event.target.value;
-            if (isValidColorString(newColor)) {
-                setTextColor(newColor);
-            }
-        },
+        (event: React.ChangeEvent<HTMLInputElement>) => setTextColor(event.target.value),
         [setTextColor]
     );
 


### PR DESCRIPTION
When actually applying the the value in the color text box to the column, I validate that the color is of a valid hexadecimal RGB form first (via `isValidColorString`).

https://github.com/ctrl-alt-lalit/kanban/blob/652de2b0f27944a515f106c2a620c658a9cc2416/src/components/column/color-picker.tsx#L81-L84

But I was also doing this every time a user attempted to edit the text field. In the process of changing the text field's value, you'll generally have an interim "invalid" state (e.g., backspace reducing the length to 5), so this resulted in the text box appearing un-editable.

So the change is just removing that every-time-you-change-a-character validation.
```diff
const onInputChange = React.useCallback(
-        (event: React.ChangeEvent<HTMLInputElement>) => {
-            const newColor = event.target.value;
-            if (isValidColorString(newColor)) {
-                setTextColor(newColor);
-            }
-        },
+        (event: React.ChangeEvent<HTMLInputElement>) => setTextColor(event.target.value),
        [setTextColor]
);
```

